### PR TITLE
Fix missing DS

### DIFF
--- a/Plugin/Framework/File/Uploader/ObjectUploader.php
+++ b/Plugin/Framework/File/Uploader/ObjectUploader.php
@@ -95,7 +95,7 @@ class ObjectUploader
             $baseName = $result['file'] ?? '';
 
             /** @var string $realPath */
-            $realPath = $basePath . $baseName;
+            $realPath = $basePath . DIRECTORY_SEPARATOR . $baseName;
 
             if (!empty($realPath)) {
                 $this->upload($realPath);


### PR DESCRIPTION
This fixes a problem we are having with uploading WYSIWYG images:

```
[2021-07-14 14:48:49] main.CRITICAL: File "/workspace/project/pub/media/wysiwygscreenshot-gitlab.com-2021.06.29-17_00_33.png" cannot be opened Warning!fopen(/workspace/project/pub/media/wysiwygscreenshot-gitlab.com-2021.06.29-17_00_33.png): failed to open stream: No such file or directory [] []
```

(note the missing directory separator after `/wysiwyg`